### PR TITLE
Fix protobuf struct to dict conversion for config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,5 +7,5 @@ exclude=
     docs
 inline-quotes="
 import-order-style=appnexus
-application-package-names=lookout
+application-package-names=lookout.core
 per-file-ignores=**/tests/*:D

--- a/lookout/core/cmdline.py
+++ b/lookout/core/cmdline.py
@@ -8,8 +8,8 @@ from unittest.mock import patch
 
 import configargparse
 import humanfriendly
-
 import lookout
+
 from lookout.core import slogging
 from lookout.core.data_requests import DataService
 from lookout.core.event_listener import EventListener

--- a/lookout/core/manager.py
+++ b/lookout/core/manager.py
@@ -127,19 +127,16 @@ class AnalyzerManager(EventHandlers):
         while stack:
             d = stack.pop()
             if isinstance(d, dict):
-                for key in d:
-                    if isinstance(d[key], ProtobufStruct):
-                        d[key] = dict(d[key])
-                        stack.append(d[key])
-                    elif isinstance(d[key], ProtobufList):
-                        d[key] = list(d[key])
-                        stack.append(d[key])
+                keyiter = iter(d)
             elif isinstance(d, list):
-                for i in range(len(d)):
-                    if isinstance(d[i], ProtobufStruct):
-                        d[i] = dict(d[i])
-                        stack.append(d[i])
-                    elif isinstance(d[i], ProtobufList):
-                        d[i] = list(d[i])
-                        stack.append(d[i])
+                keyiter = range(len(d))
+            else:
+                keyiter = []
+            for key in keyiter:
+                if isinstance(d[key], ProtobufStruct):
+                    d[key] = dict(d[key])
+                    stack.append(d[key])
+                elif isinstance(d[key], ProtobufList):
+                    d[key] = list(d[key])
+                    stack.append(d[key])
         return mycfg

--- a/lookout/core/manager.py
+++ b/lookout/core/manager.py
@@ -1,6 +1,9 @@
 import logging
 from typing import Iterable, Sequence
 
+from google.protobuf.struct_pb2 import ListValue as ProtobufList
+from google.protobuf.struct_pb2 import Struct as ProtobufStruct
+
 from lookout.core.analyzer import Analyzer, DummyAnalyzerModel, ReferencePointer
 from lookout.core.api.event_pb2 import PushEvent, ReviewEvent
 from lookout.core.api.service_analyzer_pb2 import EventResponse
@@ -57,7 +60,7 @@ class AnalyzerManager(EventHandlers):
         comments = []
         for analyzer in self._analyzers:
             try:
-                mycfg = dict(request.configuration[analyzer.name])
+                mycfg = self._protobuf_struct_to_dict(request.configuration[analyzer.name])
                 self._log.info("%s config: %s", analyzer.name, mycfg)
             except (KeyError, ValueError):
                 mycfg = {}
@@ -91,7 +94,7 @@ class AnalyzerManager(EventHandlers):
                 continue
             self._log.debug("training %s", analyzer.name)
             try:
-                mycfg = dict(request.configuration[analyzer.name])
+                mycfg = self._protobuf_struct_to_dict(request.configuration[analyzer.name])
             except (KeyError, ValueError):
                 mycfg = {}
             model = analyzer.train(ptr, mycfg, self._data_service.get())
@@ -116,3 +119,27 @@ class AnalyzerManager(EventHandlers):
     @staticmethod
     def _model_id(analyzer: Type[Analyzer]) -> str:
         return "%s/%s" % (analyzer.name, analyzer.version)
+
+    @staticmethod
+    def _protobuf_struct_to_dict(configuration: ProtobufStruct) -> dict:
+        mycfg = dict(configuration)
+        stack = [mycfg]
+        while stack:
+            d = stack.pop()
+            if isinstance(d, dict):
+                for key in d:
+                    if isinstance(d[key], ProtobufStruct):
+                        d[key] = dict(d[key])
+                        stack.append(d[key])
+                    elif isinstance(d[key], ProtobufList):
+                        d[key] = list(d[key])
+                        stack.append(d[key])
+            elif isinstance(d, list):
+                for i in range(len(d)):
+                    if isinstance(d[i], ProtobufStruct):
+                        d[i] = dict(d[i])
+                        stack.append(d[i])
+                    elif isinstance(d[i], ProtobufList):
+                        d[i] = list(d[i])
+                        stack.append(d[i])
+        return mycfg

--- a/lookout/core/tests/test_data_requests.py
+++ b/lookout/core/tests/test_data_requests.py
@@ -4,7 +4,7 @@ import unittest
 
 import bblfsh
 
-import lookout
+import lookout.core
 from lookout.core.analyzer import ReferencePointer
 from lookout.core.api.event_pb2 import PushEvent, ReviewEvent
 from lookout.core.api.service_analyzer_pb2 import EventResponse
@@ -14,6 +14,7 @@ from lookout.core.data_requests import (DataService,
                                         with_uasts, with_uasts_and_contents)
 from lookout.core.event_listener import EventHandlers, EventListener
 from lookout.core.test_helpers import server
+import lookout.core.tests
 
 
 class DataRequestsTests(unittest.TestCase, EventHandlers):
@@ -28,7 +29,7 @@ class DataRequestsTests(unittest.TestCase, EventHandlers):
         self.server_thread = threading.Thread(target=self.run_data_service)
         self.server_thread.start()
         self.data_service = DataService("localhost:10301")
-        self.url = "file://" + str(Path(lookout.__file__).parent.absolute())
+        self.url = "file://" + str(Path(lookout.core.__file__).parent.parent.absolute())
         self.ref = "refs/heads/master"
         self.setUpWasSuccessful = True
         self.setUpEvent.wait()
@@ -54,7 +55,8 @@ class DataRequestsTests(unittest.TestCase, EventHandlers):
     def run_data_service(self):
         try:
             server.run("push", self.COMMIT_FROM, self.COMMIT_TO, self.port)
-        except Exception:
+        except Exception as e:
+            print(type(e).__name__, e)
             self.setUpWasSuccessful = False
             self.setUpEvent.set()
 


### PR DESCRIPTION
configs like
```python
{'style.format.analyzer.FormatAnalyzer': {'global': {'cutoff_label_precision': 0}}}
```
was not converted from `google.protobuf.struct_pb2.Struct` to dict correctly. 

Before we convert only the first level and get something like:
```python
 {'global': <google.protobuf.struct_pb2.Struct>}
```
and should get pure python structure as in the example.