### PR TITLE
Add log_level parameter to server.run

### DIFF
--- a/lookout/core/test_helpers/server.py
+++ b/lookout/core/test_helpers/server.py
@@ -46,7 +46,8 @@ def fetch():
         raise e from None
 
 
-def run(cmd: str, fr: str, to: str, port: int, git_dir: str=".", config_json: str=None) -> None:
+def run(cmd: str, fr: str, to: str, port: int, git_dir: str=".",
+        log_level: str="info", config_json: str=None) -> None:
     """
     Run lookout-sdk executable. If you do not have it please fetch first.
 
@@ -55,6 +56,7 @@ def run(cmd: str, fr: str, to: str, port: int, git_dir: str=".", config_json: st
     :param to: Corresponds to --to flag.
     :param port: Running analyzer port on localhost.
     :param git_dir: Corresponds to --git-dir flag.
+    :param log_level: Corresponds to --log-level flag.
     :param config_json: Corresponds to --config-json flag.
     """
     command = [
@@ -62,6 +64,7 @@ def run(cmd: str, fr: str, to: str, port: int, git_dir: str=".", config_json: st
         "--from", fr,
         "--to", to,
         "--git-dir", git_dir,
+        "--log-level", log_level,
     ]
     if config_json:
         command.extend(("--config-json", config_json))


### PR DESCRIPTION
I need it to make Travis happy in this PR: 
https://github.com/src-d/style-analyzer/pull/361
It gets too many logs from `lookout-sdk` and fails with the next message.

![image](https://user-images.githubusercontent.com/516045/49318631-56d3cf80-f50a-11e8-9346-f17c8787a82a.png)

However, it looks like `--log-level` is broken anyway: https://github.com/src-d/lookout/issues/357#issuecomment-443360296