### PR TITLE
Convert floats to int

### DIFF
--- a/lookout/core/manager.py
+++ b/lookout/core/manager.py
@@ -139,4 +139,8 @@ class AnalyzerManager(EventHandlers):
                 elif isinstance(d[key], ProtobufList):
                     d[key] = list(d[key])
                     stack.append(d[key])
+                else:
+                    if isinstance(d[key], float) and d[key].is_integer():
+                        d[key] = int(d[key])
+
         return mycfg


### PR DESCRIPTION
Because long running tests are failed without it.