### PR TITLE
Fix filter_files expected input type

### DIFF
--- a/lookout/core/lib.py
+++ b/lookout/core/lib.py
@@ -218,7 +218,7 @@ def parse_files(filepaths: Sequence[str], content_getter: callable, line_length_
     return size_passed
 
 
-def filter_files(files: Sequence[File], line_length_limit: int, overall_size_limit: int,
+def filter_files(files: Dict[str, File], line_length_limit: int, overall_size_limit: int,
                  random_state: int = 7, log: Optional[logging.Logger] = None) -> List[File]:
     """
     Filter files based on their maximum line length and overall size.
@@ -231,12 +231,10 @@ def filter_files(files: Sequence[File], line_length_limit: int, overall_size_lim
     :param log: logger to use to report the number of excluded files.
     :return: files passed through the filter and the number of files which were excluded.
     """
-    files_by_path = {f.path: f for f in files}
-
     def content_getter(key):
-        return files_by_path[key].content
+        return files[key].content
 
-    path_passed = list(filter_files_by_path([f.path for f in files]))
+    path_passed = list(filter_files_by_path(files))
     if log is not None:
         log.debug("excluded %d/%d files by path", len(files) - len(path_passed), len(files))
     line_passed = list(
@@ -250,4 +248,4 @@ def filter_files(files: Sequence[File], line_length_limit: int, overall_size_lim
     if log is not None:
         log.debug("excluded %d/%d files by max overall size %d",
                   len(line_passed) - len(size_passed), len(line_passed), overall_size_limit)
-    return [files_by_path[filepath] for filepath in size_passed]
+    return [files[filepath] for filepath in size_passed]

--- a/lookout/core/tests/test_lib.py
+++ b/lookout/core/tests/test_lib.py
@@ -1,4 +1,5 @@
 import os
+import random
 from tempfile import NamedTemporaryFile
 import unittest
 
@@ -122,8 +123,20 @@ class LibTests(unittest.TestCase):
             finally:
                 bblfsh_client._channel.close()
 
+    def text_filter_1000_files(self):
+        def create_files():
+            files = [File(path="one", content=b"hello"),
+                     File(path="two", content=b"world" * 100)] * 1000
+            files = random.sample(files, k=len(files))  # note: no need to set the seed
+            return {file.path: file for file in files}
+
+        files1 = filter_files(create_files(), line_length_limit=80, overall_size_limit=5 << 20)
+        files2 = filter_files(create_files(), line_length_limit=80, overall_size_limit=5 << 20)
+        self.assertEqual(files1, files2)
+
     def test_filter_files(self):
         files = [File(path="one", content=b"hello"), File(path="two", content=b"world" * 100)]
+        files = {file.path: file for file in files}
         logged = False
 
         class Log:


### PR DESCRIPTION
We expect as input values from `files_by_language` output and it is already `Dict[str, File]` so we should not convert it. 