### PR TITLE
Include load_file into the parse_files method

### DIFF
--- a/lookout/core/lib.py
+++ b/lookout/core/lib.py
@@ -157,7 +157,7 @@ def filter_files_by_overall_size(filepaths: Iterable[str], content_getter: calla
         yield key
 
 
-def parse_files(filepaths: Sequence[str], content_getter: callable, line_length_limit: int,
+def parse_files(filepaths: Sequence[str], line_length_limit: int,
                 overall_size_limit: int, client: BblfshClient, language: str,
                 random_state: int = 7, progress_tracker: Callable = lambda x: x,
                 log: Optional[logging.Logger] = None) -> Iterable[File]:
@@ -170,7 +170,6 @@ def parse_files(filepaths: Sequence[str], content_getter: callable, line_length_
     and hence different from `filepaths`.
 
     :param filepaths: File paths to filter.
-    :param content_getter: Function which returns the file byte content by it's path.
     :param line_length_limit: Maximum line length to accept a file.
     :param overall_size_limit: Maximum cumulative files size in bytes. \
                                The files are discarded after reaching this limit.
@@ -181,10 +180,14 @@ def parse_files(filepaths: Sequence[str], content_getter: callable, line_length_
     :param log: Logger to use to report the number of excluded files.
     :return: `File`-s with parsed UASTs and which passed through the filters.
     """
+    def load_file(path):
+        with open(path, "rb") as f:
+            return f.read()
+
     random.seed(random_state)
     filepaths_filtered = list(filter_files_by_path(filepaths))
     files_filtered_by_line_length = sorted(
-        filter_files_by_line_length(filepaths_filtered, content_getter, line_length_limit))
+        filter_files_by_line_length(filepaths_filtered, load_file, line_length_limit))
     files_filtered_by_line_length = random.sample(files_filtered_by_line_length,
                                                   k=len(files_filtered_by_line_length))
     size, n_parsed = 0, 0

--- a/lookout/core/tests/test_lib.py
+++ b/lookout/core/tests/test_lib.py
@@ -11,11 +11,6 @@ from lookout.core.lib import extract_changed_nodes, files_by_language, filter_fi
     find_new_lines, parse_files
 
 
-def load_file(path):
-    with open(path, "rb") as f:
-        return f.read()
-
-
 class LibTests(unittest.TestCase):
     def test_find_deleted_lines(self):
         text_base = """
@@ -116,7 +111,7 @@ class LibTests(unittest.TestCase):
             tmp2.seek(0)
             try:
                 bblfsh_client = BblfshClient("0.0.0.0:9432")
-                filtered = parse_files(filepaths=[tmp1.name, tmp2.name], content_getter=load_file,
+                filtered = parse_files(filepaths=[tmp1.name, tmp2.name],
                                        line_length_limit=80, overall_size_limit=5 << 20,
                                        client=bblfsh_client, language="javascript", log=Log())
                 self.assertEqual(len(filtered), 1)


### PR DESCRIPTION
Signed-off-by: Waren Long <waren@sourced.tech>

I need this in order to remove `prepare_files` from `style-analyzer` and use `parse_files` instead